### PR TITLE
This commit fixes issue #27 by adding the encoding parameter to every open function in each source file.

### DIFF
--- a/pytablecon/pytable_csv.py
+++ b/pytablecon/pytable_csv.py
@@ -10,7 +10,7 @@ def mdtable_to_csv(file_name: str) -> None:
     """
     # Get Markdown table
     md_lines: list[str] = []
-    with open(file_name) as md_file:
+    with open(file_name, encoding="utf-8") as md_file:
         for i in md_file:
             md_lines.append(i)
 
@@ -30,7 +30,7 @@ def mdtable_to_csv(file_name: str) -> None:
     
     # Output to file
     output_path: str = file_name.replace(ptc.MARKDOWN_FILE_EXTENSION, ptc.CSV_FILE_EXTENSION)
-    with open(output_path, mode="w", newline="") as output_file:
+    with open(output_path, mode="w", newline="", encoding="utf-8") as output_file:
         writer = csv.writer(output_file)
         writer.writerows(str_lines)
 
@@ -42,7 +42,7 @@ def tsv_to_csv(file_name: str) -> None:
     file_name: contains the path of the file that is to be converted.
     """
     tsv_lines: list[str] = []
-    with open(file_name) as tsv_file:
+    with open(file_name, encoding="utf-8") as tsv_file:
         for i in tsv_file:
             tsv_lines.append(i)
     
@@ -50,5 +50,5 @@ def tsv_to_csv(file_name: str) -> None:
     csv_lines: list[str] = [','.join(x) for x in processed_lines]
 
     output_path: str = file_name.replace(ptc.TSV_FILE_EXTENSION, ptc.CSV_FILE_EXTENSION)
-    with open(output_path, "w") as output_file:
+    with open(output_path, "w", encoding="utf-8") as output_file:
         output_file.writelines(csv_lines)

--- a/pytablecon/pytable_html.py
+++ b/pytablecon/pytable_html.py
@@ -10,7 +10,7 @@ def csv_to_html(file_name: str) -> None:
     file_name: Contains the path of the file that is to be converted.
     """
     table_lines: list[str] = []
-    with open(file_name) as csv_file:
+    with open(file_name, encoding="utf-8") as csv_file:
         csv_reader = csv.reader(csv_file)
 
         csv_iter = iter(csv_reader)
@@ -31,7 +31,7 @@ def csv_to_html(file_name: str) -> None:
 
     output_to_file(file_name, ptc.CSV_FILE_EXTENSION, ptc.HTML_FILE_EXTENSION, table_lines)
 
-def tsv_to_html(file_name):
+def tsv_to_html(file_name: str):
     """
     Converts a TSV file to an HTML document with no CSS styling.
 
@@ -40,7 +40,7 @@ def tsv_to_html(file_name):
     """
     table_lines = []
     tsv_lines = []
-    with open(file_name) as tsv_file:
+    with open(file_name, encoding="utf-8") as tsv_file:
         for line in tsv_file:
             tsv_lines.append(line.strip('\n').split('\t'))
     
@@ -72,7 +72,7 @@ def mdtable_to_html(file_name: str) -> None:
     table_lines: list[str] = []
     md_table_lines: list[str] = []
 
-    with open(file_name) as md_file:
+    with open(file_name, encoding="utf-8") as md_file:
         for line in md_file:
             md_table_lines.append(line.strip('\n'))
     
@@ -112,7 +112,7 @@ def output_to_file(file_name: str, orig_format: str, output_format: str, table_l
     name_temp: list[str] = file_name.split('.')[-2].split('/')[-1]
     html_head = ' '*4 + "<head>\n" + ' '*8 + f"<title>{name_temp}</title>\n" + ' '*4 + "</head>\n"
     output_path = file_name.replace(orig_format, output_format)
-    with open(output_path, "w") as output_file:
+    with open(output_path, "w", encoding="utf-8") as output_file:
         output_file.write("<!DOCTYPE HTML>\n<html>\n")
         output_file.write(html_head)
         output_file.write(' '*4 + "<body>\n")

--- a/pytablecon/pytable_md.py
+++ b/pytablecon/pytable_md.py
@@ -9,7 +9,7 @@ def csv_to_mdtable(file_name: str) -> None:
     file_name: Contains the path of the file that is to be converted.
     """
     md_lines: list[str] = []
-    with open(file_name) as csv_file:
+    with open(file_name, encoding="utf-8") as csv_file:
         csv_reader = csv.reader(csv_file)
 
         csv_iter = iter(csv_reader)
@@ -22,7 +22,7 @@ def csv_to_mdtable(file_name: str) -> None:
             md_lines.append("| " + " | ".join(line) + " |\n")
 
     output_path: str = file_name.replace(ptc.CSV_FILE_EXTENSION, ptc.MARKDOWN_FILE_EXTENSION)
-    with open(output_path, mode="w") as output_file:
+    with open(output_path, mode="w", encoding="utf-8") as output_file:
         output_file.writelines(md_lines)
 
 def tsv_to_mdtable(file_name: str) -> None:
@@ -33,7 +33,7 @@ def tsv_to_mdtable(file_name: str) -> None:
     file_name: Contains the path of the file that is to be converted.
     """
     tsv_lines: list[str] = []
-    with open(file_name) as tsv_file:
+    with open(file_name, encoding="utf-8") as tsv_file:
         for line in tsv_file:
             tsv_lines.append(line)
    
@@ -46,7 +46,7 @@ def tsv_to_mdtable(file_name: str) -> None:
     processed_lines.insert(1, alignment_cols + '\n')
 
     output_path = file_name.replace(ptc.TSV_FILE_EXTENSION, ptc.MARKDOWN_FILE_EXTENSION)
-    with open(output_path, mode="w") as output_file:
+    with open(output_path, mode="w", encoding="utf-8") as output_file:
         output_file.writelines(processed_lines)
 
 def md_alignment_columns(cols: str, delimiter: str) -> str:

--- a/pytablecon/pytable_tsv.py
+++ b/pytablecon/pytable_tsv.py
@@ -12,7 +12,7 @@ def mdtable_to_tsv(file_name: str) -> None:
     """
     # Get Markdown table
     md_lines: list[str] = []
-    with open(file_name) as md_file:
+    with open(file_name, encoding="utf-8") as md_file:
         for i in md_file:
             md_lines.append(i)
 
@@ -35,7 +35,7 @@ def mdtable_to_tsv(file_name: str) -> None:
         joined_str.append("\t".join(i) + '\n')
     
     output_path: str = file_name.replace(ptc.MARKDOWN_FILE_EXTENSION, ptc.TSV_FILE_EXTENSION)
-    with open(output_path, "w") as output_file:
+    with open(output_path, "w", encoding="utf-8") as output_file:
         output_file.writelines(joined_str)
 
 def csv_to_tsv(file_name: str) -> None:
@@ -47,7 +47,7 @@ def csv_to_tsv(file_name: str) -> None:
     """
     tsv_lines: list[str] = []
 
-    with open(file_name) as csv_file:
+    with open(file_name, encoding="utf-8") as csv_file:
         csv_reader = csv.reader(csv_file)
         for row in csv_reader:
             tsv_lines.append('\t'.join(row) + '\n')
@@ -56,5 +56,5 @@ def csv_to_tsv(file_name: str) -> None:
         file_name_parts[-1] = ptc.TSV_FILE_EXTENSION
         output_file_path: str = '.'.join(file_name_parts)
         print(output_file_path)
-        with open(output_file_path, mode="w") as output_file:
+        with open(output_file_path, mode="w", encoding="utf-8") as output_file:
             output_file.writelines(tsv_lines)


### PR DESCRIPTION
Went through all the source files to include the `encoding` parameter to the `open` function. This should fix the UTF-8 encoding error that Python gives when opening certain files.